### PR TITLE
Add wpp tracing to FS filter driver

### DIFF
--- a/FsFilter1/FsFilter1.vcxproj
+++ b/FsFilter1/FsFilter1.vcxproj
@@ -35,6 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="wpp.cpp" />
     <ResourceCompile Include="FsFilter1.rc" />
     <ClCompile Include="FsFilter1.cpp" />
     <Inf Include="FsFilter1.inf" />
@@ -151,11 +152,21 @@
     <Link>
       <AdditionalDependencies>fltmgr.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>RUN_WPP;WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WppEnabled>true</WppEnabled>
+      <WppTraceFunction>TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);</WppTraceFunction>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>fltmgr.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>RUN_WPP;WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WppEnabled>true</WppEnabled>
+      <WppTraceFunction>TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);</WppTraceFunction>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>
@@ -182,6 +193,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FsFilter1.h" />
+    <ClInclude Include="Trace.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/FsFilter1/Trace.h
+++ b/FsFilter1/Trace.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#if !defined WPPFILE || !defined RUN_WPP    // To enable Wpp; Select Yes under Run Wpp Tracing in Project properties
+#undef WPPFILE                              // And define both RUN_WPP and WPPFILE="%(FileName).tmh" in C/C++ preprocessor
+#undef RUN_WPP                              // To disable Wpp; Select No under Run Wpp Tracing; undef RUN_WPP/WPPFILE in C/C++ preprocessor
+#endif
+
+static const int TRACE_FATAL = 1;
+static const int TRACE_ERROR = 2;
+static const int TRACE_WARNING = 3;
+static const int TRACE_INFO = 4;
+static const int TRACE_VERBOSE = 5;
+static const int TRACE_NOISY = 8;
+
+#if defined RUN_WPP && defined WPPFILE
+#define WPPNAME		FsfilterTraceGuid
+#define WPPGUID		cea490b7,b23b,4bc5,986e,f79949bea6a9
+
+#define WPP_DEFINE_DEFAULT_BITS                                        \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                              \
+        WPP_DEFINE_BIT(TRACE_KDPRINT)                                  \
+        WPP_DEFINE_BIT(DEFAULT_TRACE_LEVEL)
+
+#undef WPP_DEFINE_CONTROL_GUID	
+#define WPP_CONTROL_GUIDS \
+    WPP_DEFINE_CONTROL_GUID(WPPNAME,(WPPGUID), \
+        WPP_DEFINE_DEFAULT_BITS )
+
+#define WPP_FLAGS_LEVEL_LOGGER(Flags, level)                                  \
+    WPP_LEVEL_LOGGER(Flags)
+
+#define WPP_FLAGS_LEVEL_ENABLED(Flags, level)                                 \
+    (WPP_LEVEL_ENABLED(Flags) && \
+    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) \
+           WPP_LEVEL_LOGGER(flags)
+
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) \
+           (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+
+// begin_wpp config
+// FUNC dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_INFO}(MSG, ...);
+// FUNC TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
+// end_wpp
+
+#include WPPFILE
+
+#else
+
+#undef WPP_INIT_TRACING
+#define WPP_INIT_TRACING(...)	((void)(0, __VA_ARGS__))
+
+#undef WPP_CLEANUP
+#define WPP_CLEANUP(...)	((void)(0, __VA_ARGS__))
+#endif
+
+#ifndef WPP_CHECK_INIT
+#define WPP_CHECK_INIT
+#endif
+
+
+void WppInit(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath);
+
+void WppCleanup(PDRIVER_OBJECT pDriverObject);

--- a/FsFilter1/wpp.cpp
+++ b/FsFilter1/wpp.cpp
@@ -1,0 +1,14 @@
+#include <ntddk.h>
+#include "Trace.h"
+
+void
+WppInit(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath)
+{
+    WPP_INIT_TRACING(pDriverObject, pRegistryPath);
+}
+
+void
+WppCleanup(PDRIVER_OBJECT pDriverObject)
+{
+    WPP_CLEANUP(pDriverObject);
+}


### PR DESCRIPTION
Use below commands to create/start 'logman session' before starting filtering the files
logman create trace FsFilter -p {cea490b7-b23b-4bc5-986e-f79949bea6a9} 0xFFFFFFFF 5 -nb 1 1 -bs 1  -max 100 -o C:\PerfLogs\FsFilter.etl
logman start FsFilter

Once session is created and started, etl file gets created and updated with TraceEvent messages

To stop and delete the session
logman stop FsFilter
logman delete FsFilter